### PR TITLE
More self-explanatory name

### DIFF
--- a/metadata.ini
+++ b/metadata.ini
@@ -2,7 +2,7 @@
 collections=pism_resources
 
 [pism_resources]
-name=PISM QGIS Resources
+name=Glaciological Symbols 
 author=Andy Aschwanden
 email=andy.aschwanden@gmail.com
 tags=glaciology, Greenland, Antartica, PISM


### PR DESCRIPTION
Please note that the collection names should stand for themselves and help users find collections they are interested in. Collection names like "PISM" are not self-explanatory and users will have a hard time finding useful collections if they just see a list of random abbreviations.