### PR TITLE
Make these resources available also for QGIS 3 users

### DIFF
--- a/metadata.ini
+++ b/metadata.ini
@@ -11,4 +11,4 @@ license=This collection is released under CC0.
 license_file=license
 preview=preview/pism-qgis-preview.png
 qgis_minimum_version=2.0
-qgis_maximum_version=2.99
+qgis_maximum_version=3.99


### PR DESCRIPTION
I don't know if these resources work with QGIS 3, but if they do, changing `qgis_maximum_version` to 3.99 will make sure that they are available for QGIS 3 users.